### PR TITLE
chore: align tooling to canonical ESM stack

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -21,8 +21,15 @@ export default {
     'json',
     'node',
   ],
-  testPathIgnorePatterns: ['/node_modules/', '/frontend/', '/dist/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/frontend/',
+    '/dist/',
+    '/packages/',
+  ],
   resetModules: false,
+  globalSetup: './test/setup.ts',
+  globalTeardown: './test/teardown.ts',
   collectCoverage: true,
   coverageDirectory: './.out',
   collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}', '!src/**/*.d.ts'],
@@ -33,4 +40,14 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: './.out',
+        outputName: 'junit.xml',
+      },
+    ],
+  ],
 };

--- a/knip.config.js
+++ b/knip.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  entry: ['src/index.ts'],
-  ignoreDependencies: [
-    '@semantic-release/.*?',
-    '@commitlint/config-conventional',
-  ],
-};

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,4 @@
+export default {
+  ignore: ['knip.config.ts'],
+  ignoreDependencies: [/^@semantic-release\//],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
-        "@commitlint/config-conventional": "^19.8.1",
         "@jest/globals": "^30.0.0",
         "@mridang/eslint-defaults": "^1.4.0",
         "@rollup/plugin-commonjs": "^28.0.3",
@@ -35,13 +34,13 @@
         "@types/xml2js": "^0.4.14",
         "eslint": "^9.0.0",
         "jest": "^30.0.3",
+        "jest-junit": "^17.0.0",
         "jsonwebtoken": "^9.0.2",
         "knip": "^5.43.6",
         "nock": "^14.0.5",
         "prettier": "^3.1.1",
         "rollup": "^4.41.1",
         "semantic-release": "^25.0.1",
-        "semantic-release-major-tag": "^0.3.2",
         "ts-jest": "^29.4.0",
         "tslib": "^2.8.1",
         "typescript": "^5.9.3"
@@ -1019,34 +1018,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@commitlint/config-conventional": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
-      "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commitlint/types": "^19.8.1",
-        "conventional-changelog-conventionalcommits": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/types": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
-      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/conventional-commits-parser": "^5.0.0",
-        "chalk": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=v18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3956,16 +3927,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/conventional-commits-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
-      "integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -6103,19 +6064,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -10344,6 +10292,35 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-junit": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^14.0.0",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -16220,16 +16197,6 @@
         "node": "^22.14.0 || >= 24.10.0"
       }
     },
-    "node_modules/semantic-release-major-tag": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/semantic-release-major-tag/-/semantic-release-major-tag-0.3.2.tgz",
-      "integrity": "sha512-XTB3mVG6D6oPHSW/zhWC3eSoBRiLqZjKtjTc90wcLzS0DG00UORnn7CceDGdYc5dIl0BG91eO873HvECimyE+Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/semantic-release/node_modules/aggregate-error": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
@@ -18113,6 +18080,20 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -18431,6 +18412,13 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml2js": {
       "version": "0.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "prettier": "^3.1.1",
         "rollup": "^4.41.1",
         "semantic-release": "^25.0.1",
+        "semantic-release-major-tag": "^0.3.2",
         "ts-jest": "^29.4.0",
         "tslib": "^2.8.1",
         "typescript": "^5.9.3"
@@ -16195,6 +16196,16 @@
       },
       "engines": {
         "node": "^22.14.0 || >= 24.10.0"
+      }
+    },
+    "node_modules/semantic-release-major-tag": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/semantic-release-major-tag/-/semantic-release-major-tag-0.3.2.tgz",
+      "integrity": "sha512-XTB3mVG6D6oPHSW/zhWC3eSoBRiLqZjKtjTc90wcLzS0DG00UORnn7CceDGdYc5dIl0BG91eO873HvECimyE+Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/semantic-release/node_modules/aggregate-error": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "prettier": "^3.1.1",
     "rollup": "^4.41.1",
     "semantic-release": "^25.0.1",
+    "semantic-release-major-tag": "^0.3.2",
     "ts-jest": "^29.4.0",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "prepack": "tsc",
     "build": "rollup --config=rollup.config.mjs",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --verbose --config=jest.config.mjs --runInBand",
+    "test": "jest --verbose --config=jest.config.mjs",
     "test:watch": "npm run test -- --watch",
-    "test:debug": "jest --verbose --config=jest.config.mjs --runInBand --detectOpenHandles",
+    "test:debug": "jest --verbose --config=jest.config.mjs --detectOpenHandles",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "npx eslint .",
@@ -55,7 +55,6 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@commitlint/config-conventional": "^19.8.1",
     "@jest/globals": "^30.0.0",
     "@mridang/eslint-defaults": "^1.4.0",
     "@rollup/plugin-commonjs": "^28.0.3",
@@ -75,13 +74,13 @@
     "@types/xml2js": "^0.4.14",
     "eslint": "^9.0.0",
     "jest": "^30.0.3",
+    "jest-junit": "^17.0.0",
     "jsonwebtoken": "^9.0.2",
     "knip": "^5.43.6",
     "nock": "^14.0.5",
     "prettier": "^3.1.1",
     "rollup": "^4.41.1",
     "semantic-release": "^25.0.1",
-    "semantic-release-major-tag": "^0.3.2",
     "ts-jest": "^29.4.0",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,32 +1,37 @@
-// noinspection JSUnusedGlobalSymbols
+import { readFileSync } from 'fs';
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+);
+
 export default {
   branches: ['master'],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     [
-      '@semantic-release/exec',
+      '@semantic-release/npm',
       {
-        prepareCmd: 'npm run build',
+        npmPublish: true,
+        pkgRoot: '.',
+        tarballDir: '.',
+        access: 'public',
       },
     ],
     [
       '@semantic-release/github',
       {
-        assets: ['action.yml', 'dist/**'],
-        successComment: false,
-        failComment: false,
+        assets: [{ path: '*.tgz', label: 'Package' }],
       },
     ],
     [
       '@semantic-release/git',
       {
-        assets: ['package.json', 'package-lock.json', 'dist'],
+        assets: ['package.json', 'package-lock.json'],
         message:
           'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],
-    'semantic-release-major-tag',
   ],
-  repositoryUrl: 'git+https://github.com/mridang/action-test-reporter.git',
+  repositoryUrl: packageJson.repository.url,
 };

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,37 +1,32 @@
-import { readFileSync } from 'fs';
-
-const packageJson = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
-);
-
+// noinspection JSUnusedGlobalSymbols
 export default {
   branches: ['master'],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     [
-      '@semantic-release/npm',
+      '@semantic-release/exec',
       {
-        npmPublish: true,
-        pkgRoot: '.',
-        tarballDir: '.',
-        access: 'public',
+        prepareCmd: 'npm run build',
       },
     ],
     [
       '@semantic-release/github',
       {
-        assets: [{ path: '*.tgz', label: 'Package' }],
+        assets: ['action.yml', 'dist/**'],
+        successComment: false,
+        failComment: false,
       },
     ],
     [
       '@semantic-release/git',
       {
-        assets: ['package.json', 'package-lock.json'],
+        assets: ['package.json', 'package-lock.json', 'dist'],
         message:
           'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],
+    'semantic-release-major-tag',
   ],
-  repositoryUrl: packageJson.repository.url,
+  repositoryUrl: 'git+https://github.com/mridang/action-test-reporter.git',
 };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,4 @@
+// noinspection JSUnusedGlobalSymbols
+export default async function setup(): Promise<void> {
+  // No external services are required for the test suite.
+}

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -1,0 +1,4 @@
+// noinspection JSUnusedGlobalSymbols
+export default async function teardown(): Promise<void> {
+  // No external services to tear down.
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -8,7 +8,8 @@
     "allowJs": true,
     "sourceMap": true,
     "declaration": false,
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["**/*"],
   "exclude": ["node_modules", "**/*.spec.ts", "dist"]


### PR DESCRIPTION
## Description

Aligns this repo's tooling with the canonical ESM stack used across all mridang repos: canonical `jest.config.mjs` (with global setup/teardown and jest-junit reporter), `knip.config.ts` (renamed from `knip.config.js`), canonical `release.config.mjs` (npm publish + GitHub release + git assets), and a `tsconfig.jest.json` rootDir alignment. New `test/setup.ts` and `test/teardown.ts` stubs are added. The `--experimental-vm-modules` flag lives in `.npmrc` already, so `package.json` scripts are simplified to drop the inline `NODE_OPTIONS` and `--runInBand`.

Restores per-archetype `release.config.mjs` so semantic-release uses the correct publishing pipeline.

## Related Issue

N/A — tooling alignment chore.

## Motivation and Context

Keeps tooling byte-identical across mridang repos so configs, lint rules, and release flow behave consistently.

## How Has This Been Tested?

- [ ] CI `lint` green
- [ ] CI `format` green
- [ ] CI `test` green
- [ ] CI `build` green

## Documentation:

N/A.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities